### PR TITLE
Implement Auto Shutdown for Minecraft Server Container

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -20,6 +20,9 @@ param discordBotPublicKey string = ''
 @secure()
 param discordBotToken string = ''
 
+@description('Automatically shut down the server at midnight.')
+param deployAutoShutdown bool = true
+
 // Server
 module storageServer 'modules/storage-server.bicep' = {
   name: 'storageServer'
@@ -106,6 +109,18 @@ module discordBot 'modules/discord-bot.bicep' = if(deployDiscordBot && discordBo
     discordBotToken: discordBotToken
 
     containerLaunchManagerRoleId: roles.outputs.roleDefinitionContainerLaunchManagerId
+  }
+}
+
+// Auto shutdown
+module autoShutdown 'modules/auto-shutdown.bicep' = if (deployAutoShutdown) {
+  name: 'autoShutdown'
+  params: {
+    location: location
+    projectName: name
+    
+    containerGroupName: server.outputs.containerGroupName
+    roleDefinitionId: roles.outputs.roleDefinitionContainerLaunchManagerId
   }
 }
 

--- a/infra/modules/auto-shutdown.bicep
+++ b/infra/modules/auto-shutdown.bicep
@@ -1,0 +1,31 @@
+param location string
+param projectName string
+
+param containerGroupName string
+param roleDefinitionId string
+
+var logicAppName = 'logic-${projectName}-auto-shutdown'
+
+resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2023-05-01' existing = {
+  name: containerGroupName
+}
+
+resource logicApp 'Microsoft.Logic/workflows@2019-05-01' = {
+  name: logicAppName
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+  }
+}
+
+// Role assignment
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(logicApp.id, roleDefinitionId)
+  scope: containerGroup
+  properties: {
+    principalId: logicApp.identity.principalId
+    roleDefinitionId: roleDefinitionId
+  }
+}

--- a/infra/modules/auto-shutdown.bicep
+++ b/infra/modules/auto-shutdown.bicep
@@ -4,6 +4,19 @@ param projectName string
 param containerGroupName string
 param roleDefinitionId string
 
+param recurrence object = {
+  frequency: 'Day'
+  interval: '1'
+  schedule: {
+    hours: [
+      '3'
+    ]
+    minutes: [
+      0
+    ]
+  }
+}
+
 var logicAppName = 'logic-${projectName}-auto-shutdown'
 
 resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2023-05-01' existing = {
@@ -17,6 +30,45 @@ resource logicApp 'Microsoft.Logic/workflows@2019-05-01' = {
     type: 'SystemAssigned'
   }
   properties: {
+    definition: {
+      '$schema': 'https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#'
+      actions: {
+        'HTTP_-_POST_-_ARM_Container_Stop': {
+          inputs: {
+            authentication: {
+              type: 'ManagedServiceIdentity'
+            }
+            method: 'POST'
+            uri: '${environment().resourceManager}@{parameters(\'containerId\')}/stop?api-version=${containerGroup.apiVersion}'
+          }
+          runAfter: {}
+          type: 'Http'
+        }
+      }
+      contentVersion: '1.0.0.0'
+      parameters: {
+        containerId: {
+          defaultValue: containerGroup.id
+          type: 'String'
+        }
+        '$connections': {
+          defaultValue: {}
+          type: 'Object'
+        }
+      }
+      triggers: {
+        Recurrence: {
+          evaluatedRecurrence: recurrence
+          recurrence: recurrence
+          type: 'Recurrence'
+        }
+      }
+    }
+    parameters: {
+      '$connections': {
+        value: {}
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This pull request primarily focuses on adding an auto-shutdown feature to the server. It includes changes to the `infra/main.bicep` and `infra/modules/auto-shutdown.bicep` files. The main changes include the addition of the `deployAutoShutdown` parameter, the creation of the `autoShutdown` module, and the implementation of the auto-shutdown feature in the `auto-shutdown.bicep` file.

Auto-shutdown feature addition:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R23-R25): Added a new parameter `deployAutoShutdown` to control whether the auto-shutdown feature should be deployed or not.
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R115-R126): Created a new module `autoShutdown` which is only deployed if `deployAutoShutdown` is true. This module takes in parameters like location, project name, container group name, and role definition ID.

Auto-shutdown feature implementation:

* [`infra/modules/auto-shutdown.bicep`](diffhunk://#diff-e7d51977a407b98aa16f5d767983de4adf23afa7ff4545c464d263dceae03270R1-R83): Implemented the auto-shutdown feature. This includes defining parameters for location, project name, container group name, and role definition ID. A recurrence object is defined to schedule the shutdown. A logic app is created to stop the container group at the scheduled time. The logic app is assigned a role to have the necessary permissions to stop the container group.