### PR TITLE
Improve GitHub Workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,9 @@ name: Build and Publish Azure Minecraft
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -24,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -37,7 +38,7 @@ jobs:
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v4.1.1
         with:
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           file: ./src/discord-bot/Azmc.DiscordBot/Dockerfile
           context: ./src/discord-bot
           tags: ${{ steps.meta.outputs.tags }}
@@ -65,7 +66,7 @@ jobs:
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v4.1.1
         with:
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           file: ./src/map-renderer/Dockerfile
           context: ./src/map-renderer
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
-name: Azure Minecraft
+name: Build and Publish Azure Minecraft
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -49,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build Infrastructure as Code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build Bicep File
         run: az bicep build --file infra/main.bicep
 
@@ -22,7 +22,7 @@ jobs:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}/discord-bot
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -50,7 +50,7 @@ jobs:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}/map-renderer
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,0 +1,43 @@
+name: Tag Docker Images on Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  tag_images:
+    name: Tag Docker Images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image_name: [discord-bot, map-renderer]
+        dockerfile: [./src/discord-bot/Azmc.DiscordBot/Dockerfile, ./src/map-renderer/Dockerfile]
+        context: [./src/discord-bot, ./src/map-renderer]
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}/${{ matrix.image_name }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Tag Docker Images
+        run: |
+          docker buildx build --platform linux/amd64,linux/arm64 --tag ${{ env.REGISTRY }}/${{ matrix.image_name }}:latest --file ${{ matrix.dockerfile }} ${{ matrix.context }}
+          docker buildx build --platform linux/amd64,linux/arm64 --tag ${{ env.REGISTRY }}/${{ matrix.image_name }}:${{ github.ref_name }} --file ${{ matrix.dockerfile }} ${{ matrix.context }}
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Docker Images
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ matrix.image_name }}:latest
+          docker push ${{ env.REGISTRY }}/${{ matrix.image_name }}:${{ github.ref_name }}


### PR DESCRIPTION
This pull request primarily focuses on improving the GitHub Actions workflows for building and publishing Docker images in the `.github/workflows/main.yml` and `.github/workflows/tag-version.yml` files. The key changes include modifying the triggers for the workflows, updating the Docker login action version, and controlling when Docker images are pushed.

Workflow Triggers and Naming:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L1-R7): The workflow name has been changed to "Build and Publish Azure Minecraft", and it has been configured to trigger on push and pull request events to the main branch, in addition to the existing workflow dispatch trigger.

Docker Login Action Version Updates:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L24-R28): The Docker login action version has been updated from v2.2.0 to v3 in two jobs. This update may include performance improvements and bug fixes. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L24-R28) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L52-R56)

Docker Image Push Control:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L37-R41): The Docker build and push action has been updated in two jobs to push images only when the GitHub reference is the main branch. This change prevents unnecessary pushes for other branches. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L37-R41) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L65-R69)

New Workflow for Tagging Docker Images:

* [`.github/workflows/tag-version.yml`](diffhunk://#diff-6c6aa7701d328255c9477222846cfce62dc4a0c2401f1fd3e2d79b19c5d61b1cR1-R43): A new workflow has been added to tag Docker images on release. The workflow triggers when a new release is created and builds, tags, and pushes Docker images for the discord-bot and map-renderer.