### PR TITLE
Fix: Simplify Main Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
   pull_request:
   workflow_dispatch:
 
@@ -16,11 +15,11 @@ jobs:
         run: az bicep build --file infra/main.bicep
 
   build_discord-bot:
-    name: Build and Push Discord Bot
+    name: Build Discord Bot
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build and Push Docker Image
+      - name: Build Docker Image
         uses: docker/build-push-action@v5
         with:
           push: false
@@ -28,11 +27,11 @@ jobs:
           context: ./src/discord-bot
 
   build_map-renderer:
-    name: Build and Push Map Renderer
+    name: Build Map Renderer
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build and Push Docker Image
+      - name: Build Docker Image
         uses: docker/build-push-action@v5
         with:
           push: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Azure Minecraft
+name: Build Azure Minecraft
 
 on:
   push:
@@ -18,55 +18,23 @@ jobs:
   build_discord-bot:
     name: Build and Push Discord Bot
     runs-on: ubuntu-latest
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}/discord-bot
     steps:
       - uses: actions/checkout@v4
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract Metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: false
           file: ./src/discord-bot/Azmc.DiscordBot/Dockerfile
           context: ./src/discord-bot
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
 
   build_map-renderer:
     name: Build and Push Map Renderer
     runs-on: ubuntu-latest
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}/map-renderer
     steps:
       - uses: actions/checkout@v4
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract Metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: false
           file: ./src/map-renderer/Dockerfile
           context: ./src/map-renderer
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build Azure Minecraft
+name: Build
 
 on:
   push:

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,4 +1,4 @@
-name: Tag Docker Images on Release
+name: Release Docker Images
 
 on:
   release:


### PR DESCRIPTION
This pull request includes changes to GitHub Actions workflows in the `.github/workflows` directory. The changes primarily focus on simplifying the build process and removing the push operations to the GitHub Container Registry. The workflows affected include `main.yml` and `tag-version.yml`.

Changes to the build process:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L1-L5): The build process has been simplified by removing the push operations to the GitHub Container Registry. This includes the removal of environment variables related to the registry and image name, the login step to the GitHub Container Registry, the extraction of metadata, and the tagging and labeling of images. The changes affect the `build_discord-bot` and `build_map-renderer` jobs. The workflow now only builds the Docker images without pushing them. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L1-L5) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L19-L72)

Changes to workflow names:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L1-L5): The name of the workflow has been changed from "Build and Publish Azure Minecraft" to "Build". The names of the jobs within the workflow have also been changed to reflect the removal of the push operations. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L1-L5) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L19-L72)
* [`.github/workflows/tag-version.yml`](diffhunk://#diff-6c6aa7701d328255c9477222846cfce62dc4a0c2401f1fd3e2d79b19c5d61b1cL1-R1): The name of the workflow has been changed from "Tag Docker Images on Release" to "Release Docker Images".