### PR TITLE
Hotfix wrong Discord Bot Docker image

### DIFF
--- a/infra/modules/discord-bot.bicep
+++ b/infra/modules/discord-bot.bicep
@@ -5,7 +5,7 @@ param projectName string
 param containerEnvironmentId string
 
 @description('The docker image to use for the bot. This should be a public image. Leave the default value if you don\'t know what this is.')
-param botDockerImage string = 'ghcr.io/ginomessmer/azmc/discord-bot:feature-bot'
+param botDockerImage string = 'ghcr.io/ginomessmer/azmc/discord-bot'
 
 @description('The resource ID of the container group that runs the Minecraft server. This is used to interact with the server.')
 param minecraftContainerGroupName string


### PR DESCRIPTION
This pull request includes a change to the `infra/modules/discord-bot.bicep` file. The `botDockerImage` parameter's default value has been updated to use the main version of the Discord bot Docker image instead of a feature-specific version.