### PR TITLE
Add Workflow for Azure Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Azure Deployment
+
+on:
+  workflow_dispatch: 
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: development
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Azure CLI
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy Infrastructure to Azure
+        run: az deployment group create -f infra/main.bicep -g ${{ secrets.AZURE_RG_NAME }} -p discordBotPublicKey="${{ secrets.DISCORD_BOT_PUBLIC_KEY }}" -p discordBotToken="${{ secrets.DISCORD_BOT_TOKEN }}" ${{ vars.AZ_DEPLOYMENT_INLINE_PARAMS }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying the application to Azure. The workflow is manually triggered (`workflow_dispatch`) and requires an input for the environment to deploy to. The workflow runs on an Ubuntu machine and uses the Azure CLI to deploy the infrastructure to Azure. The deployment uses several secrets for authentication and configuration.

Key changes:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R26): Created a new GitHub Actions workflow for Azure deployment. This workflow is manually triggered and requires an environment input. It runs on an Ubuntu machine and uses the Azure CLI for deployment. The deployment uses several secrets for authentication and configuration.