### PR TITLE
Improve Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,13 +39,13 @@ jobs:
               ${{ vars.AZ_DEPLOYMENT_INLINE_PARAMS }} > whatif
 
       # Create string output of Whatif
-      - name: Create String Output
+      - name: Create String Output of What If
         id: whatif-string
         run: |
           WHATIF=$(cat whatif)
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
-          echo "## Whatif Output" >> $GITHUB_OUTPUT
+          echo "## ARM What If Output" >> $GITHUB_OUTPUT
           echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
           echo '```' >> $GITHUB_OUTPUT
@@ -55,7 +55,7 @@ jobs:
           echo "${delimiter}" >> $GITHUB_OUTPUT
 
       # Publish Terraform Plan as task summary
-      - name: Publish Whatif to Task Summary
+      - name: Publish What If to Task Summary
         env:
           SUMMARY: ${{ steps.whatif-string.outputs.summary }}
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,14 @@ on:
 permissions: 
   id-token: write
 
+env:
+  AZ_INLINE_SCRIPT_PARAMS: |
+    -f infra/main.bicep \
+    -g ${{ secrets.AZURE_RG_NAME }} \
+    -p discordBotPublicKey="${{ secrets.DISCORD_BOT_PUBLIC_KEY }}" \
+    -p discordBotToken="${{ secrets.DISCORD_BOT_TOKEN }}" \
+    ${{ vars.AZ_DEPLOYMENT_INLINE_PARAMS }} > whatif
+
 jobs:
   what_if:
     runs-on: ubuntu-latest
@@ -32,11 +40,7 @@ jobs:
         with:
           inlineScript: |
             az deployment group what-if \
-              -f infra/main.bicep \
-              -g ${{ secrets.AZURE_RG_NAME }} \
-              -p discordBotPublicKey="${{ secrets.DISCORD_BOT_PUBLIC_KEY }}" \
-              -p discordBotToken="${{ secrets.DISCORD_BOT_TOKEN }}" \
-              ${{ vars.AZ_DEPLOYMENT_INLINE_PARAMS }} > whatif
+              ${{ env.AZ_INLINE_SCRIPT_PARAMS }}
 
       # Create string output of Whatif
       - name: Create String Output of What If
@@ -81,8 +85,4 @@ jobs:
         with:
           inlineScript: |
             az deployment group create \
-              -f infra/main.bicep \
-              -g ${{ secrets.AZURE_RG_NAME }} \
-              -p discordBotPublicKey="${{ secrets.DISCORD_BOT_PUBLIC_KEY }}" \
-              -p discordBotToken="${{ secrets.DISCORD_BOT_TOKEN }}" \
-              ${{ vars.AZ_DEPLOYMENT_INLINE_PARAMS }}
+              ${{ env.AZ_INLINE_SCRIPT_PARAMS }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
   what_if:
     runs-on: ubuntu-latest
     name: What If
+    environment: ${{ github.event.inputs.environment }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,11 @@ on:
         required: true
         default: development
         type: environment
+      whatif_only:
+        description: 'Only run What If'
+        required: false
+        default: false
+        type: boolean
 
 permissions: 
   id-token: write
@@ -70,6 +75,7 @@ jobs:
     name: Deploy to Azure
     needs: what_if
     environment: ${{ github.event.inputs.environment }}
+    if: ${{ github.event.inputs.whatif_only == 'false' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,12 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy Infrastructure to Azure
-        run: az deployment group create -f infra/main.bicep -g ${{ secrets.AZURE_RG_NAME }} -p discordBotPublicKey="${{ secrets.DISCORD_BOT_PUBLIC_KEY }}" -p discordBotToken="${{ secrets.DISCORD_BOT_TOKEN }}" ${{ vars.AZ_DEPLOYMENT_INLINE_PARAMS }}
+        uses: azure/cli@v1
+        with:
+          inlineScript: |
+            az deployment group create \
+              -f infra/main.bicep \
+              -g ${{ secrets.AZURE_RG_NAME }} \
+              -p discordBotPublicKey="${{ secrets.DISCORD_BOT_PUBLIC_KEY }}" \
+              -p discordBotToken="${{ secrets.DISCORD_BOT_TOKEN }}" \
+              ${{ vars.AZ_DEPLOYMENT_INLINE_PARAMS }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Azure CLI
+      - name: Login to Azure
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Azure Deployment
+name: Deploy to Azure
 
 on:
   workflow_dispatch: 
@@ -8,9 +8,13 @@ on:
         required: true
         default: development
 
+permissions: 
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    name: Deploy to Azure
     environment: ${{ github.event.inputs.environment }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Azure
+name: Deploy
 
 on:
   workflow_dispatch: 
@@ -7,6 +7,7 @@ on:
         description: 'Environment to deploy to'
         required: true
         default: development
+        type: environment
 
 permissions: 
   id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
               -g ${{ secrets.AZURE_RG_NAME }} \
               -p discordBotPublicKey="${{ secrets.DISCORD_BOT_PUBLIC_KEY }}" \
               -p discordBotToken="${{ secrets.DISCORD_BOT_TOKEN }}" \
-              ${{ vars.AZ_DEPLOYMENT_INLINE_PARAMS }} > what-if
+              ${{ vars.AZ_DEPLOYMENT_INLINE_PARAMS }} > whatif
 
       # Create string output of Whatif
       - name: Create String Output

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,57 @@ permissions:
   id-token: write
 
 jobs:
+  what_if:
+    runs-on: ubuntu-latest
+    name: What If
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Azure
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: What If
+        uses: azure/cli@v1
+        with:
+          inlineScript: |
+            az deployment group what-if \
+              -f infra/main.bicep \
+              -g ${{ secrets.AZURE_RG_NAME }} \
+              -p discordBotPublicKey="${{ secrets.DISCORD_BOT_PUBLIC_KEY }}" \
+              -p discordBotToken="${{ secrets.DISCORD_BOT_TOKEN }}" \
+              ${{ vars.AZ_DEPLOYMENT_INLINE_PARAMS }} > what-if
+
+      # Create string output of Whatif
+      - name: Create String Output
+        id: whatif-string
+        run: |
+          WHATIF=$(cat whatif)
+          delimiter="$(openssl rand -hex 8)"
+          echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
+          echo "## Whatif Output" >> $GITHUB_OUTPUT
+          echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo '```' >> $GITHUB_OUTPUT
+          echo "$WHATIF" >> $GITHUB_OUTPUT
+          echo '```' >> $GITHUB_OUTPUT
+          echo "</details>" >> $GITHUB_OUTPUT
+          echo "${delimiter}" >> $GITHUB_OUTPUT
+
+      # Publish Terraform Plan as task summary
+      - name: Publish Whatif to Task Summary
+        env:
+          SUMMARY: ${{ steps.whatif-string.outputs.summary }}
+        run: |
+          echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+
   deploy:
     runs-on: ubuntu-latest
     name: Deploy to Azure
+    needs: what_if
     environment: ${{ github.event.inputs.environment }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Docker Images
+name: Release
 
 on:
   release:

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -142,5 +142,6 @@ module dashboards 'dashboards/default.bicep' = if(deployDashboard) {
   }
 }
 
-output minecraftServerEndpoint string = server.outputs.containerGroupFqdn
+output minecraftServerContainerGroupName string = server.outputs.containerGroupName
+output minecraftServerFqdn string = server.outputs.containerGroupFqdn
 output discordInteractionEndpoint string? = deployDiscordBot ? format('https://{0}/interactions', discordBot.outputs.containerAppUrl)   : null

--- a/infra/utils/gh-identity.bicep
+++ b/infra/utils/gh-identity.bicep
@@ -1,0 +1,57 @@
+// Use this template (independently) to create a user-assigned managed identity for GitHub Actions.
+// E.g. az deployment group create -f infra/utils/gh-identity.bicep -g <<YOUR RG NAME>> -p name <<PROJECT NAME SIMILIAR USED IN MAIN>> 
+
+param name string
+param location string = resourceGroup().location
+
+param repo string = 'ginomessmer/azmc'
+param environment string = 'development'
+
+var subject = 'repo:${repo}:environment:${environment}'
+var identityName = 'id-${name}-gh-actions'
+
+
+resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-07-31-preview' = {
+  name: identityName
+  location: location
+
+  resource federatedCredentials 'federatedIdentityCredentials' = {
+    name: 'github-actions_default'
+    properties: {
+      audiences: [
+        'api://AzureADTokenExchange'
+      ]
+      issuer: 'https://token.actions.githubusercontent.com'
+      subject: subject
+    }
+  }
+}
+
+// Role assignment
+var ownerRoleDefinitionName = '8e3af657-a8ff-443c-a75c-2fe8c4bcb635'
+resource ownerRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-05-01-preview' existing = {
+  name: ownerRoleDefinitionName
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(identity.id, ownerRoleDefinition.id)
+  scope: resourceGroup()
+  properties: {
+    principalId: identity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: ownerRoleDefinition.id
+  }
+}
+
+// Lock
+resource identityLock 'Microsoft.Authorization/locks@2020-05-01' = {
+  name: 'identityLock'
+  scope: identity
+  dependsOn: [
+    roleAssignment
+  ]
+  properties: {
+    level: 'ReadOnly'
+    notes: 'Lock to prevent accidental modification to this identity to keep GitHub actions working.'
+  }
+}


### PR DESCRIPTION
This pull request involves significant changes to the GitHub workflows and Azure infrastructure deployment. The most important changes include renaming the workflows, adding a "What If" job in the deployment workflow, modifying output parameters in the `main.bicep` file, and creating a new `gh-identity.bicep` file for GitHub Actions.

GitHub Workflows:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L1-R1): The workflow name has been changed to "Deploy" and a "What If" job has been added. This new job logs into Azure, runs a "What If" command to preview the deployment, and creates a summary of the "What If" command's output. The "Deploy" job now depends on the "What If" job and will only run if the `whatif_only` input is false. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L1-R1) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R10-R94)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L1-R1): The workflow has been renamed from `tag-version.yml` to `release.yml` and the name of the workflow has been changed to "Release".

Azure Infrastructure:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L145-R146): The output parameters have been modified to include `minecraftServerContainerGroupName` and `minecraftServerFqdn`.
* [`infra/utils/gh-identity.bicep`](diffhunk://#diff-e27c63e1e093c4573e4adb297ddd0784617790ba966409229ce9865b2b1ca0a9R1-R57): A new file has been added to create a user-assigned managed identity for GitHub Actions. This identity is given the owner role and is locked to prevent accidental modification.