### PR TITLE
Implement CDN for Web Map (Caching, Compression)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -146,4 +146,4 @@ output minecraftServerContainerGroupName string = server.outputs.containerGroupN
 output minecraftServerFqdn string = server.outputs.containerGroupFqdn
 output discordInteractionEndpoint string? = deployDiscordBot ? format('https://{0}/interactions', discordBot.outputs.containerAppUrl)   : null
 
-output webMapContainerAppName string = deployRenderer ? renderer.outputs.webMapContainerAppName : ''
+output webMapFqdn string = deployRenderer ? renderer.outputs.webMapFqdn : ''

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -10,6 +10,8 @@ param deployDashboard bool = true
 
 @description('Deploy the map renderer module (EXPERIMENTAL).')
 param deployRenderer bool = false
+@description('Use the CDN to serve the rendered map. If false, the rendered map will be served from the Container App.')
+param useCdn bool = true
 
 @description('Deploy the Discord bot module. Make sure to supply the public key and token.')
 param deployDiscordBot bool = false
@@ -89,6 +91,7 @@ module renderer 'modules/renderer.bicep' = if(deployRenderer) {
     projectName: name
     containerEnvironmentName: containerEnvironment.outputs.containerEnvironmentName
     mapRendererStorageAccountName: storageRenderer.outputs.storageAccountPublicMapName
+    useCdn: useCdn
   }
 }
 

--- a/infra/modules/renderer.bicep
+++ b/infra/modules/renderer.bicep
@@ -172,7 +172,7 @@ resource cdn 'Microsoft.Cdn/profiles@2023-07-01-preview' = if (useCdn) {
   }
   
   resource endpoint 'endpoints' = {
-    name: projectName
+    name: '${projectName}-map'
     location: 'Global'
     properties: {
       originHostHeader: webMapContainerApp.properties.latestRevisionFqdn


### PR DESCRIPTION
This pull request primarily focuses on improvements to the `infra/main.bicep` and `infra/modules/renderer.bicep` files. The key changes involve the addition of a Content Delivery Network (CDN) to the web map, which can enhance performance, enable caching, and support compression. The output parameters have also been updated to reflect these changes.

Key changes include:

Changes to output parameters:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L149-R149): Changed the output parameter from `webMapContainerAppName` to `webMapFqdn`, which reflects the fully qualified domain name (FQDN) of the web map instead of the app name.

Addition of CDN:

* [`infra/modules/renderer.bicep`](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14R7-R14): Added a new parameter `useCdn` to decide whether to use a CDN for the web map. This can improve performance, enable caching, and support compression, but may incur additional costs.
* [`infra/modules/renderer.bicep`](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14R167-R207): Added a new resource `cdn` of type `Microsoft.Cdn/profiles@2023-07-01-preview` if `useCdn` is true. The CDN endpoint is configured to compress 'image/png' and 'application/json' content types, allow HTTPS, and use the query string for caching.
* [`infra/modules/renderer.bicep`](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14R167-R207): Updated the output parameter `webMapFqdn` to return the hostname of the CDN endpoint if `useCdn` is true, otherwise it returns the FQDN of the `webMapContainerApp`.