### PR TITLE
Fix Host Names for Azure CDN

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -13,6 +13,8 @@ param deployRenderer bool = false
 @description('Use the CDN to serve the rendered map. If false, the rendered map will be served from the Container App.')
 param useCdn bool = true
 
+param mapHostName string = ''
+
 @description('Deploy the Discord bot module. Make sure to supply the public key and token.')
 param deployDiscordBot bool = false
 @description('The public key for the Discord bot. Only required if deployDiscordBot is true.')
@@ -92,6 +94,7 @@ module renderer 'modules/renderer.bicep' = if(deployRenderer) {
     containerEnvironmentName: containerEnvironment.outputs.containerEnvironmentName
     mapRendererStorageAccountName: storageRenderer.outputs.storageAccountPublicMapName
     useCdn: useCdn
+    webMapHostName: mapHostName
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -8,11 +8,11 @@ param acceptEula bool
 @description('Deploy the built-in Azure Portal dashboards.')
 param deployDashboard bool = true
 
-@description('Deploy the map renderer module (EXPERIMENTAL).')
+@description('Deploy the map renderer module.')
 param deployRenderer bool = false
 @description('Use the CDN to serve the rendered map. If false, the rendered map will be served from the Container App.')
 param useCdn bool = true
-
+@description('The host name for the web map.')
 param mapHostName string = ''
 
 @description('Deploy the Discord bot module. Make sure to supply the public key and token.')

--- a/infra/modules/renderer.bicep
+++ b/infra/modules/renderer.bicep
@@ -199,6 +199,35 @@ resource cdn 'Microsoft.Cdn/profiles@2023-07-01-preview' = if (useCdn) {
           }
         }
       ]
+      deliveryPolicy: {
+        rules: [
+          {
+            name: 'RedirectToHttps'
+            conditions: [
+              {
+                name: 'RequestScheme'
+                parameters: {
+                  operator: 'Equal'
+                  typeName: 'DeliveryRuleRequestSchemeConditionParameters'
+                  matchValues: [ 'HTTP' ]
+                  negateCondition: false
+                }
+              }
+            ]
+            actions: [
+              {
+                name: 'UrlRedirect'
+                parameters: {
+                  redirectType: 'Found'
+                  typeName: 'DeliveryRuleUrlRedirectActionParameters'
+                  destinationProtocol: 'Https'
+                }
+              }
+            ]
+            order: 1
+          }
+        ]
+      }
     }
 
     resource domain 'customDomains' = if (webMapHostName != '') {

--- a/infra/modules/renderer.bicep
+++ b/infra/modules/renderer.bicep
@@ -202,7 +202,7 @@ resource cdn 'Microsoft.Cdn/profiles@2023-07-01-preview' = if (useCdn) {
     }
 
     resource domain 'customDomains' = if (webMapHostName != '') {
-      name: webMapHostName
+      name: replace(webMapHostName, '.', '-')
       properties: {
         hostName: webMapHostName
       }


### PR DESCRIPTION
This pull request primarily focuses on the enhancement of the map rendering module and the configuration of the Content Delivery Network (CDN) in the `infra/main.bicep` and `infra/modules/renderer.bicep` files. The key changes include the removal of the experimental tag from the map rendering module, introduction of a new parameter for the web map host name, and updates to the CDN configuration.

Updates to map rendering module:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L11-R16): Removed the experimental tag from the map rendering module and introduced a new parameter `mapHostName` for the web map host name.
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R97): Included the new `mapHostName` parameter in the renderer module.
* [`infra/modules/renderer.bicep`](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14R10-R11): Added the `webMapHostName` parameter.

Changes to CDN configuration:

* [`infra/modules/renderer.bicep`](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14L178-R180): Updated the `originHostHeader` and `hostName` properties in the CDN resource to use the `fqdn` from the `ingress` configuration of the `webMapContainerApp`. [[1]](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14L178-R180) [[2]](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14L190-R237)
* [`infra/modules/renderer.bicep`](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14L190-R237): Added a `deliveryPolicy` to the CDN resource to redirect HTTP requests to HTTPS, and added a new `customDomains` resource when `webMapHostName` is not empty.