### PR TITLE
Add resource pack support to server module

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -31,6 +31,12 @@ param discordBotPublicKey string = ''
 @secure()
 param discordBotToken string = ''
 
+// Resources
+@description('Deploy the services required to host resources, such as resource packs.')
+param deployResources bool = true
+@description('The file name of the resource pack to deploy. Make sure to upload the resource pack to the storage account using the same name. Only required if deployResources is true.')
+param resourcePackName string = ''
+
 // Auto shutdown
 @description('Automatically shut down the server at midnight.')
 param deployAutoShutdown bool = true
@@ -58,6 +64,7 @@ module server 'modules/server.bicep' = {
     serverShareName: storageServer.outputs.storageAccountFileShareServerName
     workspaceName: logs.outputs.workspaceName
     memorySize: serverMemorySize
+    resourcePackUrl: (deployResources && resourcePackName != '') ? '${resources.outputs.storageAccountResourcePackEndpoint}/${resourcePackName}' : ''
   }
 }
 
@@ -139,6 +146,15 @@ module autoShutdown 'modules/auto-shutdown.bicep' = if (deployAutoShutdown) {
   }
 }
 
+// Resources
+module resources 'modules/storage-resources.bicep' = if(deployResources) {
+  name: 'resources'
+  params: {
+    location: location
+    projectName: name
+  }
+}
+
 // Access management
 module roles 'modules/roles.bicep' = {
   name: 'roles'
@@ -159,6 +175,6 @@ module dashboards 'dashboards/default.bicep' = if(deployDashboard) {
 
 output minecraftServerContainerGroupName string = server.outputs.containerGroupName
 output minecraftServerFqdn string = server.outputs.containerGroupFqdn
-output discordInteractionEndpoint string? = deployDiscordBot ? format('https://{0}/interactions', discordBot.outputs.containerAppUrl)   : null
+output discordInteractionEndpoint string? = deployDiscordBot ? format('https://{0}/interactions', discordBot.outputs.containerAppUrl) : null
 
 output webMapFqdn string = deployRenderer ? renderer.outputs.webMapFqdn : ''

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -37,6 +37,9 @@ param deployResources bool = true
 @description('The file name of the resource pack to deploy. Make sure to upload the resource pack to the storage account using the same name. Only required if deployResources is true.')
 param resourcePackName string = ''
 
+@description('Determines if the resource pack is hosted externally. If true, the resource pack will be linked to the Minecraft server. If false, AZMC assumes that the resource pack is hosted on the deployed resources storage account.')
+var isResourcePackExternal = startsWith(resourcePackName, 'https://')
+
 // Auto shutdown
 @description('Automatically shut down the server at midnight.')
 param deployAutoShutdown bool = true
@@ -64,7 +67,10 @@ module server 'modules/server.bicep' = {
     serverShareName: storageServer.outputs.storageAccountFileShareServerName
     workspaceName: logs.outputs.workspaceName
     memorySize: serverMemorySize
-    resourcePackUrl: (deployResources && resourcePackName != '') ? '${resources.outputs.storageAccountResourcePackEndpoint}/${resourcePackName}' : ''
+    resourcePackUrl: (deployResources && resourcePackName != '') || isResourcePackExternal
+      ? isResourcePackExternal
+        ? resourcePackName : '${resources.outputs.storageAccountResourcePackEndpoint}/${resourcePackName}'
+      : ''
   }
 }
 

--- a/infra/modules/server.bicep
+++ b/infra/modules/server.bicep
@@ -21,6 +21,9 @@ param isAutostopEnabled string = 'TRUE'
 @description('Accept the Minecraft EULA.')
 param acceptEula bool
 
+@description('The URL of the Minecraft resource pack.')
+param resourcePackUrl string
+
 // Log Analytics settings
 param workspaceName string
 
@@ -59,6 +62,10 @@ var minecraftContainer = {
       {
         name: 'MEMORY'
         value: '${memorySize}G'
+      }
+      {
+        name: 'RESOURCE_PACK'
+        value: resourcePackUrl != '' ? resourcePackUrl : ''
       }
     ]
     volumeMounts: [

--- a/infra/modules/storage-resources.bicep
+++ b/infra/modules/storage-resources.bicep
@@ -1,0 +1,36 @@
+param location string
+param projectName string
+
+var const = loadJsonContent('../const.json')
+
+var normalizedProjectName = replace(projectName, '-', '')
+var storageAccountName = '${const.abbr.storageAccount}${normalizedProjectName}res'
+
+resource storageAccountResources 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: true
+    supportsHttpsTrafficOnly: true
+  }
+
+  resource blobServices 'blobServices' = {
+    name: 'default'
+
+    resource resourcePackContainer 'containers' = {
+      name: 'packs'
+      properties: {
+        publicAccess: 'Blob'
+      }
+    }
+  } 
+}
+
+output storageAccountName string = storageAccountResources.name
+output storageAccountResourcePackEndpoint string = '${storageAccountResources.properties.primaryEndpoints.blob}/${storageAccountResources::blobServices::resourcePackContainer.name}'
+

--- a/infra/modules/storage-resources.bicep
+++ b/infra/modules/storage-resources.bicep
@@ -32,5 +32,5 @@ resource storageAccountResources 'Microsoft.Storage/storageAccounts@2023-01-01' 
 }
 
 output storageAccountName string = storageAccountResources.name
-output storageAccountResourcePackEndpoint string = '${storageAccountResources.properties.primaryEndpoints.blob}/${storageAccountResources::blobServices::resourcePackContainer.name}'
+output storageAccountResourcePackEndpoint string = '${storageAccountResources.properties.primaryEndpoints.blob}${storageAccountResources::blobServices::resourcePackContainer.name}'
 


### PR DESCRIPTION
This pull request primarily introduces the ability to deploy resources such as resource packs in the `infra/main.bicep` and `infra/modules/server.bicep` files. The changes include the addition of new parameters and modules to handle resource deployment, as well as modifications to existing modules to accommodate this feature. 

Resource Deployment:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R34-R39): Added new parameters `deployResources` and `resourcePackName` to enable and manage resource deployment. Also, a new module `resources` was added to deploy resources if `deployResources` is set to true. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R34-R39) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R149-R157)
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R67): Modified the `server` module to include a `resourcePackUrl` property, which is calculated based on the `deployResources` and `resourcePackName` parameters.
* [`infra/modules/server.bicep`](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfR24-R26): Added a new parameter `resourcePackUrl` and modified the `minecraftContainer` variable to include a `RESOURCE_PACK` environment variable, which is set to the value of `resourcePackUrl`. [[1]](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfR24-R26) [[2]](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfR66-R69)

New File Addition:

* [`infra/modules/storage-resources.bicep`](diffhunk://#diff-93a8d07ca2322f07a3f61a8c1f943cd3bd8ae52ba1d7952f1181bcfd2f09e0afR1-R36): A new file was added to handle the creation of a storage account for resources, with the name of the storage account being based on the project name. This storage account is configured to allow public access to blobs over HTTPS only. An output `storageAccountResourcePackEndpoint` was added to provide the endpoint for accessing the resource pack.