### PR TITLE
Use Paper MC as Default Server Type

### DIFF
--- a/docs/adr/server-type.md
+++ b/docs/adr/server-type.md
@@ -1,0 +1,25 @@
+# Architecture Decision Record: Switch from Spigot to Paper MC
+
+## Context
+
+We are currently using the Spigot Minecraft server for our game server infrastructure. However, we have been experiencing limitations with Spigot, and we believe that switching to Paper MC might address these concerns.
+
+## Decision
+
+After evaluating the features and performance improvements offered by Paper MC, we have decided to switch from Spigot to Paper MC as the default Minecraft server type.
+
+## Consequences
+
+- **Improved performance**: Paper MC is known for its optimizations and performance enhancements, which can result in a smoother gameplay experience for players.
+- **Enhanced features**: Paper MC offers additional features and improvements over Spigot, such as improved chunk loading, entity tracking, and tick handling.
+- **Compatibility**: Paper MC is designed to be compatible with existing Spigot plugins, ensuring that current plugins will continue to work without major modifications.
+- **Community support**: Paper MC has a large and active community, providing ongoing support, bug fixes, and updates.
+
+## Alternatives Considered
+
+We considered the following alternatives before making this decision:
+- Optimizing Spigot: We could have invested time and effort into optimizing our Spigot server configuration and plugins. However, this approach might not have provided the same level of performance improvements as switching to Paper MC. Additionally, it would have added development and maintenance overhead.
+- Other server software: We explored other Minecraft server software options, such as Bukkit and Forge. However, after evaluating their features and community support, we determined that Paper MC was the best choice for our needs.
+
+## Related ADRs
+n/a

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -5,9 +5,10 @@ param name string = 'azmc'
 @description('Accept the Minecraft Server EULA.')
 @allowed([true])
 param acceptEula bool
-
 @description('The memory size of the server in GB. Increase for large servers or maps.')
 param serverMemorySize int = 3
+@description('The type of server to deploy. Check the documentation for the list of supported server types: https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/. Commonly used types are SPIGOT, PAPER, and FORGE.')
+param serverType string = 'SPIGOT'
 
 // Dashboard
 @description('Deploy the built-in Azure Portal dashboards.')
@@ -62,6 +63,7 @@ module server 'modules/server.bicep' = {
   params: {
     location: location
     acceptEula: acceptEula
+    serverType: serverType
     projectName: name
     serverStorageAccountName: storageServer.outputs.storageAccountServerName
     serverShareName: storageServer.outputs.storageAccountFileShareServerName

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -8,7 +8,7 @@ param acceptEula bool
 @description('The memory size of the server in GB. Increase for large servers or maps.')
 param serverMemorySize int = 3
 @description('The type of server to deploy. Check the documentation for the list of supported server types: https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/. Commonly used types are SPIGOT, PAPER, and FORGE.')
-param serverType string = 'SPIGOT'
+param serverType string = 'PAPER'
 
 // Dashboard
 @description('Deploy the built-in Azure Portal dashboards.')

--- a/infra/modules/server.bicep
+++ b/infra/modules/server.bicep
@@ -6,8 +6,12 @@ param serverShareName string = 'server'
 param serverStorageAccountName string
 
 // Minecraft settings
+// Most settings can be found at https://docker-minecraft-server.readthedocs.io/
 @description('The Minecraft version of the server.')
 param minecraftVersion string = 'LATEST'
+
+@description('The type of the server.')
+param serverType string = 'SPIGOT'
 
 @description('Recommended size: min. 3 GB RAM')
 param memorySize int = 3
@@ -28,7 +32,6 @@ param resourcePackUrl string
 param workspaceName string
 
 var serverMountPath = '/data'
-var serverType = 'SPIGOT'
 
 var containerGroupName = 'ci-${projectName}-server'
 


### PR DESCRIPTION
This pull request primarily focuses on introducing a new parameter `serverType` to the `infra/main.bicep` and `infra/modules/server.bicep` files. The `serverType` parameter allows the type of Minecraft server to be specified during deployment. The default server type is set to 'SPIGOT'. The changes also include the removal of a hardcoded `serverType` value in `infra/modules/server.bicep`.

Here are the key changes:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L8-R11): Introduced a new parameter `serverType` with a default value of 'SPIGOT'. This parameter is also passed to the `server` module. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L8-R11) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R66)
* [`infra/modules/server.bicep`](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfR9-R15): Added a new parameter `serverType` and removed the hardcoded `serverType` value. [[1]](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfR9-R15) [[2]](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfL31)

These changes provide more flexibility in the deployment of Minecraft servers by allowing the server type to be specified.