### PR TITLE
Fix Storage Access Tier for Server File Share

### DIFF
--- a/docs/adr/server-storage-tier.md
+++ b/docs/adr/server-storage-tier.md
@@ -1,0 +1,32 @@
+# Architecture Decision Record: Switching Server Azure File Share Storage Tier
+
+## Context
+
+We are currently hosting a Minecraft server on Azure and utilizing an Azure file share for storing game data. The server has high transactional requirements but relatively low storage usage. We are considering switching the storage tier from hot to transaction optimized to optimize costs.
+
+## Decision
+
+After careful consideration, we have decided to switch the storage tier of the server Azure file share from hot to transaction optimized.
+
+## Consequences
+
+The decision to switch to the transaction optimized tier has the following consequences:
+
+- Cost Optimization: The transaction optimized tier is more cost-effective for workloads with high transactional requirements and low storage usage. By switching to this tier, we can reduce our storage costs while still meeting the performance needs of the Minecraft server.
+- Performance: The transaction optimized tier provides lower latency and higher throughput for transactional workloads. This will help ensure smooth gameplay and responsiveness for players on the Minecraft server.
+- Storage Capacity: The transaction optimized tier offers a lower storage capacity compared to the hot tier. However, since our Minecraft server has relatively low storage usage, this reduction in capacity is not a concern for us.
+
+## Alternatives Considered
+
+We considered the following alternatives before making the decision:
+
+1. Hot Tier: We could have continued using the hot tier for the Azure file share. However, this would have resulted in higher storage costs due to the server's high transactional requirements.
+2. Cool Tier: Another alternative was to switch to the cool tier, which offers lower storage costs but with higher access latency. However, given the need for low latency in a real-time game like Minecraft, this option was not suitable for our requirements.
+
+## Related ADRs
+
+n/a
+
+## References
+
+- [Understand Azure Files Billing (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/files/understanding-billing)

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,23 @@
+# Architecture Decision Record: ...
+
+## Context
+
+...
+
+## Decision
+
+...
+
+## Consequences
+
+...
+
+## Alternatives Considered
+
+...
+
+## Related ADRs
+
+...
+
+## References (optional)

--- a/infra/modules/storage-map.bicep
+++ b/infra/modules/storage-map.bicep
@@ -28,10 +28,16 @@ resource storageAccountPublicMap 'Microsoft.Storage/storageAccounts@2023-01-01' 
 
     resource webShare 'shares' = {
       name: const.renderer.webShareName
+      properties: {
+        shareQuota: 256
+      }
     }
 
     resource blueMapShare 'shares' = {
       name: const.renderer.blueMapShareName
+      properties: {
+        shareQuota: 32
+      }
     }
   }
 }

--- a/infra/modules/storage-server.bicep
+++ b/infra/modules/storage-server.bicep
@@ -38,7 +38,7 @@ resource storageAccountServer 'Microsoft.Storage/storageAccounts@2023-01-01' = {
     resource serverFileShare 'shares' = {
       name: serverFileShareName
       properties: {
-        accessTier: 'Hot'
+        accessTier: 'TransactionOptimized'
         shareQuota: 256
       }
     }


### PR DESCRIPTION
This pull request includes changes to the Azure storage configuration and documentation. The most important changes include switching the storage tier of the server Azure file share from hot to transaction optimized, and updating the share quota for the webShare and blueMapShare resources.

Azure Storage Configuration:

* [`infra/modules/storage-server.bicep`](diffhunk://#diff-bda4383d385671ebfc894edbaec16d3665142ba26af9e98f66dd5d7e9b436e2eL41-R41): Changed the `accessTier` property of the `serverFileShare` resource from 'Hot' to 'TransactionOptimized'. This change is aimed at optimizing costs and performance for the Minecraft server, which has high transactional requirements but relatively low storage usage.
* [`infra/modules/storage-map.bicep`](diffhunk://#diff-8456ab04cdab51ff40ef7ea2ca24754ee8f23472b251c73d2f5a0b70c0bb05a0R31-R40): Updated the `shareQuota` property for the `webShare` and `blueMapShare` resources. The quota for `webShare` was set to 256 and for `blueMapShare` was set to 32. This change adjusts the storage capacity for these resources.

Documentation:

* [`docs/adr/server-storage-tier.md`](diffhunk://#diff-c5294a8fd7762f861c200cb4aa7a07831d05c6598be7825aeaa2d6d1f57079dcR1-R32): Added an Architecture Decision Record (ADR) detailing the decision to switch the storage tier of the server Azure file share from hot to transaction optimized. The ADR provides context, consequences, and alternatives considered for this decision.
* [`docs/template.md`](diffhunk://#diff-402df3bcefa44a9f9e2b52fe5f28ac421f7e06cbdc02ef22b5e2dac029da4d89R1-R23): Added a template for creating future Architecture Decision Records. This template will provide a consistent structure for documenting architectural decisions.