### PR TITLE
Add Minecraft Bedrock Edition Support

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -9,6 +9,8 @@ param acceptEula bool
 param serverMemorySize int = 3
 @description('The type of server to deploy. Check the documentation for the list of supported server types: https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/. Commonly used types are SPIGOT, PAPER, and FORGE.')
 param serverType string = 'PAPER'
+@description('Enable Bedrock support for the server. This will allow Bedrock clients to connect to the server.')
+param isBedrockSupportEnabled bool = false
 
 // Dashboard
 @description('Deploy the built-in Azure Portal dashboards.')
@@ -69,6 +71,7 @@ module server 'modules/server.bicep' = {
     serverShareName: storageServer.outputs.storageAccountFileShareServerName
     workspaceName: logs.outputs.workspaceName
     memorySize: serverMemorySize
+    isBedrockSupportEnabled: isBedrockSupportEnabled
     resourcePackUrl: (deployResources && resourcePackName != '') || isResourcePackExternal
       ? isResourcePackExternal
         ? resourcePackName : '${resources.outputs.storageAccountResourcePackEndpoint}/${resourcePackName}'

--- a/infra/modules/server.bicep
+++ b/infra/modules/server.bicep
@@ -22,6 +22,9 @@ param cpuCores int = 2
 @description('Enable autostop of the server when no players are online.')
 param isAutostopEnabled string = 'TRUE'
 
+@description('Enable server support for Bedrock Edition players using Geyser. Does not contain Floodgate. For more information, see https://geysermc.org/.')
+param isBedrockSupportEnabled bool = true
+
 @description('Accept the Minecraft EULA.')
 param acceptEula bool
 
@@ -46,11 +49,11 @@ var minecraftContainer = {
         port: 25565
         protocol: 'TCP'
       }
-      {
+      isBedrockSupportEnabled ? {
         // Geyser
         port: 19132
         protocol: 'UDP'
-      }
+      } : { }
     ]
     environmentVariables: [
       {
@@ -77,6 +80,12 @@ var minecraftContainer = {
         name: 'RESOURCE_PACK'
         value: resourcePackUrl != '' ? resourcePackUrl : ''
       }
+      isBedrockSupportEnabled ? {
+        name: 'PLUGINS'
+        value: [
+          'https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/spigot'
+        ]
+      } : { }
     ]
     volumeMounts: [
       {
@@ -138,10 +147,10 @@ resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2023-05-01'
           protocol: 'TCP'
           port: 25565
         }
-        {
+        isBedrockSupportEnabled ? {
           protocol: 'UDP'
           port: 19132
-        }
+        } : { }
       ]
     }
   }

--- a/infra/modules/server.bicep
+++ b/infra/modules/server.bicep
@@ -44,10 +44,12 @@ var minecraftContainer = {
       {
         // Minecraft
         port: 25565
+        protocol: 'TCP'
       }
       {
         // Geyser
         port: 19132
+        protocol: 'UDP'
       }
     ]
     environmentVariables: [

--- a/infra/modules/server.bicep
+++ b/infra/modules/server.bicep
@@ -42,7 +42,12 @@ var minecraftContainer = {
     image: 'itzg/minecraft-server'
     ports: [
       {
+        // Minecraft
         port: 25565
+      }
+      {
+        // Geyser
+        port: 19132
       }
     ]
     environmentVariables: [

--- a/infra/modules/server.bicep
+++ b/infra/modules/server.bicep
@@ -82,9 +82,7 @@ var minecraftContainer = {
       }
       isBedrockSupportEnabled ? {
         name: 'PLUGINS'
-        value: [
-          'https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/spigot'
-        ]
+        value: 'https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/spigot'
       } : { }
     ]
     volumeMounts: [

--- a/infra/modules/server.bicep
+++ b/infra/modules/server.bicep
@@ -136,6 +136,10 @@ resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2023-05-01'
           protocol: 'TCP'
           port: 25565
         }
+        {
+          protocol: 'UDP'
+          port: 19132
+        }
       ]
     }
   }


### PR DESCRIPTION
This pull request mainly introduces Bedrock support for the Minecraft server deployment in Azure. The changes include adding a new parameter `isBedrockSupportEnabled` to control Bedrock support, adjusting the server module to accommodate the new parameter, and updating the server container configuration to include the necessary ports and plugins for Bedrock support.

Addition of Bedrock Support Parameter:
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R12-R13): Added a new parameter `isBedrockSupportEnabled` to control whether Bedrock support is enabled.
* [`infra/modules/server.bicep`](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfR25-R27): Added the same `isBedrockSupportEnabled` parameter for the server module.

Server Module Adjustments:
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R74): Passed the `isBedrockSupportEnabled` parameter to the server module.

Server Container Configuration Updates:
* [`infra/modules/server.bicep`](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfR48-R56): Added conditional port and plugin configurations in the `minecraftContainer` variable based on the `isBedrockSupportEnabled` parameter. [[1]](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfR48-R56) [[2]](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfR83-R86)
* [`infra/modules/server.bicep`](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfR148-R151): Added a conditional port configuration in the `containerGroup` resource based on the `isBedrockSupportEnabled` parameter.This pull request includes changes to the `infra/modules/server.bicep` file. The main change is the addition of a new port in the `minecraftContainer` object.

The most important change is:

* [`infra/modules/server.bicep`](diffhunk://#diff-034713f394c5071a06016d6e64e80a00f8f84c710dceee70fb7535a5a36379cfR45-R51): Added a new port (19132) for Geyser in the `minecraftContainer` object. This allows the Minecraft server to communicate with the Geyser server.