### PR TITLE
Add renderer schedule parameter

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -19,6 +19,14 @@ param deployDashboard bool = true
 // Web map
 @description('Deploy the map renderer module.')
 param deployRenderer bool = false
+@description('The schedule for rendering the map. The map will be rendered at the specified interval. The supported values are weekly, daily, hourly, and every5Minutes.')
+@allowed([
+  'weekly'
+  'daily'
+  'hourly'
+  'every5Minutes'
+])
+param rendererSchedule string = 'weekly'
 @description('Use the CDN to serve the rendered map. If false, the rendered map will be served from the Container App.')
 param useCdn bool = true
 @description('The host name for the web map.')
@@ -118,6 +126,7 @@ module renderer 'modules/renderer.bicep' = if(deployRenderer) {
   params: {
     location: location
     projectName: name
+    schedule: rendererSchedule
     containerEnvironmentName: containerEnvironment.outputs.containerEnvironmentName
     mapRendererStorageAccountName: storageRenderer.outputs.storageAccountPublicMapName
     useCdn: useCdn

--- a/infra/modules/renderer.bicep
+++ b/infra/modules/renderer.bicep
@@ -9,6 +9,15 @@ param useCdn bool = true
 
 param webMapHostName string = ''
 
+@description('The schedule for the renderer job. The renderer job will be triggered according to this schedule.')
+@allowed([
+  'weekly'
+  'daily'
+  'hourly'
+  'every5Minutes'
+])
+param schedule string = 'weekly'
+
 var rendererContainerJobName = '${const.abbr.containerJob}-${projectName}-renderer'
 var renderingContainerImage = 'ghcr.io/bluemap-minecraft/bluemap:latest'
 
@@ -16,6 +25,15 @@ var webMapContainerAppName = '${const.abbr.containerApp}-${projectName}-map-web'
 var cdnName = '${const.abbr.cdn}-${projectName}-map-web'
 
 var const = loadJsonContent('../const.json')
+
+var cronSchedules = {
+  weekly: '0 0 * * 0'
+  daily: '0 0 * * *'
+  hourly: '0 * * * *'
+  every5Minutes: '*/5 * * * *'
+}
+
+var cronExpression = cronSchedules[schedule]
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
   name: mapRendererStorageAccountName
@@ -65,7 +83,7 @@ resource rendererContainerJob 'Microsoft.App/jobs@2023-08-01-preview' = {
       triggerType: 'schedule'
       replicaRetryLimit: 0
       scheduleTriggerConfig: {
-        cronExpression: '0 0 * * 0'
+        cronExpression: cronExpression
       }
     }
     template: {


### PR DESCRIPTION
This pull request primarily introduces scheduling options for the map rendering process in the `infra/main.bicep` and `infra/modules/renderer.bicep` files. The changes allow the user to set the rendering schedule to 'weekly', 'daily', 'hourly', or 'every5Minutes'. The cron expression for the rendering job is then set according to the chosen schedule.

Scheduling options introduction:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R22-R29): Added a new parameter `rendererSchedule` with a default value of 'weekly'. This parameter is then passed to the renderer module. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R22-R29) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R129)

Changes in the renderer module:

* [`infra/modules/renderer.bicep`](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14R12-R20): Introduced a new parameter `schedule` with a default value of 'weekly'. A `cronSchedules` variable was added to map schedule names to their corresponding cron expressions. The `cronExpression` for the `rendererContainerJob` resource was then set to the cron expression corresponding to the chosen schedule. [[1]](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14R12-R20) [[2]](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14R29-R37) [[3]](diffhunk://#diff-059c842e89e2e38a9fb19adac41e0753f042fcb7a52923555fe776e2f0f46d14L68-R86)