### PR TITLE
Fix what if evaluation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,14 +57,14 @@ jobs:
 
       - name: What If
         uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd
-        if: ${{ github.event.inputs.skip_whatif == 'false' && github.event.inputs.environment != 'production' }}
+        if: ${{ github.event.inputs.skip_whatif == 'false' || github.event.inputs.environment == 'production' }}
         with:
           inlineScript: |
             az deployment group what-if \
               ${{ env.AZ_INLINE_SCRIPT_PARAMS }}
 
       - name: Job Summary
-        if: ${{ github.event.inputs.skip_whatif == 'false' && github.event.inputs.environment != 'production' }}
+        if: ${{ github.event.inputs.skip_whatif == 'false' || github.event.inputs.environment == 'production' }}
         run: |
           WHATIF=$(cat whatif)
           echo "## What If Output" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/deploy.yml` file. The change modifies the conditions under which the "What If" and "Job Summary" steps are executed.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L60-R67): Changed the `if` condition for the "What If" and "Job Summary" steps to execute when `skip_whatif` is `false` or the `environment` is `production` instead of when `skip_whatif` is `false` and the `environment` is not `production`.