### PR TITLE
Auto-register Discord interaction endpoint after deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,6 +144,50 @@ jobs:
               --source config/caddy/Caddyfile \
               --path $SHARE_PATH
 
+  configure_discord:
+    runs-on: ubuntu-latest
+    name: Configure Discord Bot
+    needs: deploy
+    environment: ${{ github.event.inputs.environment }}
+    if: ${{ github.event.inputs.whatif_only == 'false' }}
+    steps:
+      - name: Login to Azure
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Set Discord Interaction Endpoint
+        run: |
+          ENDPOINT=$(az deployment group show \
+            -n ${{ env.DEPLOYMENT_NAME }} \
+            -g ${{ secrets.AZURE_RG_NAME }} \
+            --query "properties.outputs.discordInteractionEndpoint.value" \
+            -o tsv)
+
+          if [ -z "$ENDPOINT" ] || [ "$ENDPOINT" == "null" ]; then
+            echo "Discord bot not deployed — skipping endpoint registration"
+            exit 0
+          fi
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X PATCH \
+            -H "Authorization: Bot ${{ secrets.DISCORD_BOT_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"interactions_endpoint_url\": \"$ENDPOINT\"}" \
+            https://discord.com/api/v10/applications/@me)
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+          BODY=$(echo "$RESPONSE" | head -n-1)
+
+          if [ "$HTTP_CODE" -ne 200 ]; then
+            echo "Error ($HTTP_CODE): $BODY"
+            exit 1
+          fi
+
+          echo "## Discord Bot" >> $GITHUB_STEP_SUMMARY
+          echo "Interaction endpoint registered: \`$ENDPOINT\`" >> $GITHUB_STEP_SUMMARY
+
   provision-https-certificate:
     runs-on: ubuntu-latest
     name: Secure Host Names


### PR DESCRIPTION
## Summary

Closes #35

- Adds a `configure_discord` job to the deploy workflow that runs after `deploy` (parallel with `configure_map` and `provision-https-certificate`)
- Reads the `discordInteractionEndpoint` output from the Bicep deployment and calls `PATCH /applications/@me` to register it with Discord
- Reuses the existing `DISCORD_BOT_TOKEN` secret — no new secrets needed
- Skips gracefully when the Discord bot was not part of the deployment (null/empty endpoint)
- Fails with a clear error message if Discord rejects the endpoint

## Test plan

- [ ] Trigger the deploy workflow with `deployDiscordBot=true` for a dev environment and confirm the `Configure Discord Bot` step succeeds with the endpoint shown in the Step Summary
- [ ] Verify the application's "Interactions Endpoint URL" in the Discord Developer Portal matches the deployed bot FQDN
- [ ] Trigger with `deployDiscordBot=false` (or no Discord params) and confirm the step exits cleanly with the skip message

🤖 Generated with [Claude Code](https://claude.com/claude-code)